### PR TITLE
Allowed _ prefixed variables to be unused

### DIFF
--- a/VLA-Frontend/eslint.config.js
+++ b/VLA-Frontend/eslint.config.js
@@ -19,5 +19,15 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    }
   },
 ])


### PR DESCRIPTION
Small adaptation for the linter to enable the frontend usage of _* variables

Using _ as a prefix should make the use of the variable optional 

My main problem arose with window events that provide such a wrapper