### PR TITLE
Backend build speedup

### DIFF
--- a/VLA-Backend/Dockerfile
+++ b/VLA-Backend/Dockerfile
@@ -1,3 +1,4 @@
+# Adjust the CI java version of the overarching project if you change the image
 FROM gradle:8-jdk21 AS build
 WORKDIR /workspace
 


### PR DESCRIPTION
This should improve build times of the backend.

I have looked at this intensively and think that there is no functionality that is missing.

The wrapper properties are copied via the gradle folder.
It is not used here, so we could think about removing that as well, yet this won't yield a significant speedup.

On my machine it has reduced the build time by about 10s.

---

## Code Review Checklist
Not applicable here.