### PR TITLE
Added support for running gradle tasks in a local environment

### DIFF
--- a/VLA-Backend/build.gradle
+++ b/VLA-Backend/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-web' 
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-database-postgresql'
@@ -35,6 +35,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+    testImplementation "org.testcontainers:testcontainers:2.0.2"
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.testcontainers:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'


### PR DESCRIPTION
This allows running gradle tasks such as build / test / checkMainStyle, ... in Intelij / using the wrapper

I am currently using the docker engine 29.2.0 and that requires API communication of version 1.44 or above.

The implicit testcontainer dependency did not meet that requirement.
Thus, the tasks errored (for me).

Version 2.0.2 now supports this API requirement